### PR TITLE
Julia 1.x era and version 1.0 release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,6 @@ os:
   - linux
   - osx
 julia:
-  - 0.6
-  - 0.7
   - 1.0
   - nightly
 notifications:
@@ -18,6 +16,6 @@ matrix:
     - julia: nightly
 after_success:
   # push coverage results to Coveralls
-  - julia -e 'cd(Pkg.dir("PeriodicTable")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())'
+  - julia -e 'using Pkg; cd(joinpath(dirname(pathof(PeriodicTable)), "..")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())'
   # push coverage results to Codecov
-  - julia -e 'cd(Pkg.dir("PeriodicTable")); Pkg.add("Coverage"); using Coverage; Codecov.submit(Codecov.process_folder())'
+  - julia -e 'using Pkg; cd(joinpath(dirname(pathof(PeriodicTable)), "..")); Pkg.add("Coverage"); using Coverage; Codecov.submit(Codecov.process_folder())'

--- a/Project.toml
+++ b/Project.toml
@@ -3,9 +3,10 @@ uuid = "7b2266bf-644c-5ea3-82d8-af4bbd25a884"
 version = "1.0.0"
 
 [deps]
-Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
+Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 
 [compat]
-Compat = "≥ 0.33.0"
 julia = "1"
+Unitful = "1.0"

--- a/Project.toml
+++ b/Project.toml
@@ -1,0 +1,11 @@
+name = "PeriodicTable"
+uuid = "7b2266bf-644c-5ea3-82d8-af4bbd25a884"
+version = "1.0.0"
+
+[deps]
+Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
+Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
+
+[compat]
+Compat = "≥ 0.33.0"
+julia = "1"

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,0 @@
-julia 0.6
-Compat 0.33.0
-Unitful 

--- a/src/PeriodicTable.jl
+++ b/src/PeriodicTable.jl
@@ -11,7 +11,6 @@ e.g. `elements[:O]`.
 module PeriodicTable
 export Element, elements
 
-using Compat: replace
 import Unitful: u, g, cm, K, J, mol, Quantity
 
 """

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,7 +1,7 @@
-using PeriodicTable, Compat, Unitful
+using PeriodicTable, Unitful
 import Unitful: u, g, cm, K, J, mol
-using Compat.Test
-using Compat.Base64
+using Test
+using Base64
 
 @test eltype(elements) == Element
 @test length(elements) == 119 == length(collect(elements))


### PR DESCRIPTION
Get rid of the old REQUIRE and move on to the Project.toml era. This implies dropping 0.6 support which is perfectly fine IMO and allows us to drop the Compat dep. Should also fix the issue with the new TagBot GitHub action (#31).

Prepare release of version 1.0 to indicate stability.

Closes #31 