### PR TITLE
Add utility function to generate property list

### DIFF
--- a/src/PeriodicTable.jl
+++ b/src/PeriodicTable.jl
@@ -169,6 +169,8 @@ Base.get(e::Elements, i::Symbol, default) = get(e.bysymbol, i, default)
 # Utility functions
 getlist(e::Elements, i::Symbol) = getfield.(e,i)
 getlist(e::Elements, i::AbstractString) = getfield.(e,Symbol(i))
+getlist(e::Vector{Element}, i) = getlist(Elements(e),i)
+
 
 # support iterating over elements
 Base.eltype(e::Elements) = Element

--- a/src/PeriodicTable.jl
+++ b/src/PeriodicTable.jl
@@ -10,6 +10,7 @@ e.g. `elements[:O]`.
 """
 module PeriodicTable
 export Element, elements
+export getlist
 
 import Unitful: u, g, cm, K, J, mol, Quantity
 

--- a/src/PeriodicTable.jl
+++ b/src/PeriodicTable.jl
@@ -166,6 +166,10 @@ Base.get(e::Elements, i::Integer, default) = get(e.bynumber, i, default)
 Base.get(e::Elements, i::AbstractString, default) = get(e.byname, lowercase(i), default)
 Base.get(e::Elements, i::Symbol, default) = get(e.bysymbol, i, default)
 
+# Utility functions
+getlist(e::Elements, i::Symbol) = getfield.(e,i)
+getlist(e::Elements, i::AbstractString) = getfield.(e,Symbol(i))
+
 # support iterating over elements
 Base.eltype(e::Elements) = Element
 Base.length(e::Elements) = length(e.data)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -86,4 +86,4 @@ end
 @test length(getlist(elements,:symbol)) == length(elements)
 @test getlist(elements[1:2],:name) == ["Hydrogen","Helium"]
 @test getlist(elements[3:4],"symbol") == ["Li","Be"]
-@test getlist(elements[[6,74]],:density) = [1.821u"g*cm^-3",13.51u"g*cm^-3"]
+@test getlist(elements[[6,74]],:density) == [1.821u"g*cm^-3",13.51u"g*cm^-3"]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -81,3 +81,9 @@ for z in eachindex(elements)
     @test haskey(elmdict, elements[z])
     @test elmdict[elements[z]] == z
 end
+
+# Test utility function
+@test length(getlist(elements,:symbol)) == length(elements)
+@test getlist(elements[1:2],:name) == ["Hydrogen","Helium"]
+@test getlist(elements[3:4],"symbol") == ["Li","Be"]
+@test getlist(elements[[6,74]],:density) = [1.821u"g*cm^-3",13.51u"g*cm^-3"]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -86,4 +86,4 @@ end
 @test length(getlist(elements,:symbol)) == length(elements)
 @test getlist(elements[1:2],:name) == ["Hydrogen","Helium"]
 @test getlist(elements[3:4],"symbol") == ["Li","Be"]
-@test getlist(elements[[6,74]],:density) == [1.821u"g*cm^-3",13.51u"g*cm^-3"]
+@test getlist(elements[[6,74]],:density) == [1.821u"g*cm^-3",19.25u"g*cm^-3"]


### PR DESCRIPTION
## Problem

A frequent operation that is carried out using `PeriodicTable.jl` is to generate a list of element properties from `Elements`. This pull request adds a simple utility function to the [src/PeriodicTable.jl](src/PeriodicTable.jl) module.

## Solution

A new function `getlist` which returns a list  when passed a field name variable (`::Symbol` or `::String`)  of `Element` which is in `Elements`.

The following are example method calls:

```julia
getlist(elements,:name)
...
getlist(elements[1:10],"symbol")
...
getlist(elements[[6,74]],:density)
...
```

### Comments

The function/methods have been placed in `PeriodicTable.jl` module and exported from within that scope, but it may be more practical to put this in a submodule file `Utilities.jl` if more utility functions are added in the future.