### PR TITLE
Define == instead of isequal

### DIFF
--- a/src/PeriodicTable.jl
+++ b/src/PeriodicTable.jl
@@ -196,7 +196,7 @@ function Base.show(io::IO, ::MIME"text/plain", e::Elements)
 end
 
 # Since Element equality is determined by atomic number alone...
-Base.isequal(elm1::Element, elm2::Element) = elm1.number == elm2.number
+Base.:(==)(elm1::Element, elm2::Element) = elm1.number == elm2.number
 
 # There is no need to use all the data in Element to calculated the hash
 # since Element equality is determined by atomic number alone.


### PR DESCRIPTION
This defines `==` instead of `isequal`, because by default `==` falls down to `===`. It caused me some problems (that are hard to reproduce) when using two different packages that both import PeriodicTable. Namely, the same elements ended up represented by two different objects, so that they where not identical according to `===` (nor according to `==` due to the automatic fallback).

Since `isequal` falls down to `==` by default, nothing should change.

I didn't add test as a failing scenario is quite hard to come with.