### PR TITLE
Updates to contributors 

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,11 +86,8 @@ Some information has been (and will be) added over time.
 ### Related packages
 [Mendeleev](https://github.com/Eben60/Mendeleev.jl) is [API compatible](https://eben60.github.io/Mendeleev.jl/#Compatibility-Issues) with the `PeriodicTable` and contains much broader range of data on chemical elements. [IsotopeTable](https://github.com/Gregstrq/IsotopeTable.jl), also inspired by `PeriodicTable`, provides data on various isotopes.
 
-### Developed together with
-* [Steven G. Johnson](https://github.com/stevengj)
-* [Jacob Wikmark](https://github.com/lancebeet)
-* [Carsten Bauer](https://github.com/crstnbr)
-
-### Facing issues? :scream:
-* Open a PR with the detailed expaination of the issue
-* Reach me out [here](https://www.rahullakhanpal.in)
+### Contributors ✨
+<!-- markdownlint-disable -->
+<a href="https://github.com/JuliaPhysics/PeriodicTable.jl/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=JuliaPhysics/PeriodicTable.jl" />
+</a>


### PR DESCRIPTION
I believe it makes sense to update how the contributors section of the repo looks like, to account for all the awesome contributions so far! This makes sure we have all contributors displayed [see [here](https://contrib.rocks/image?repo=JuliaPhysics/PeriodicTable.jl)], along with omitting the `Facing issues` section entirely. 
